### PR TITLE
Add Rx Components

### DIFF
--- a/rxcomponents/README.md
+++ b/rxcomponents/README.md
@@ -1,4 +1,4 @@
-# Durations -- Typesafe Time Units
+# RxComponents
 
 Author: Alex Hart ([exallium](https://www.github.com/exallium))
 

--- a/rxcomponents/README.md
+++ b/rxcomponents/README.md
@@ -1,0 +1,12 @@
+# Durations -- Typesafe Time Units
+
+Author: Alex Hart ([exallium](https://www.github.com/exallium))
+
+Rx Components provides some RxJava facilities for working with different Android components.
+
+## Motivation
+
+The primary motivation for this microlib is dealing with `getActivity` within `Fragment`.  The way
+this mechanism works under the hood appears to be confusing and slightly brittle.  This microlib
+provides a container to provide the Activity when it is attached, and clear it when the Fragment is
+destroyed.

--- a/rxcomponents/build.gradle
+++ b/rxcomponents/build.gradle
@@ -4,8 +4,6 @@ apply plugin: 'kotlin'
 apply from: "$rootDir/kotlin.gradle"
 apply from: "$rootDir/spek.gradle"
 
-group = 'com.github.theREDspace.android-utils'
-
 dependencies {
     implementation "io.reactivex.rxjava2:rxjava:2.1.14"
 }

--- a/rxcomponents/build.gradle
+++ b/rxcomponents/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'java'
+apply from: "$rootDir/java.gradle"
+apply plugin: 'kotlin'
+apply from: "$rootDir/kotlin.gradle"
+
+group = 'com.github.theREDspace.android-utils'
+
+dependencies {
+    implementation "io.reactivex.rxjava2:rxjava:2.1.14"
+}

--- a/rxcomponents/build.gradle
+++ b/rxcomponents/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 apply from: "$rootDir/java.gradle"
 apply plugin: 'kotlin'
 apply from: "$rootDir/kotlin.gradle"
+apply from: "$rootDir/spek.gradle"
 
 group = 'com.github.theREDspace.android-utils'
 

--- a/rxcomponents/src/main/java/com/redspace/utils/rxcomponents/components.kt
+++ b/rxcomponents/src/main/java/com/redspace/utils/rxcomponents/components.kt
@@ -26,7 +26,7 @@ interface ComponentConsumer<C> {
  * where and when we are providing this:
  *
  * ```
- * val mgr = ComponentManager()
+ * val mgr = ComponentManager<Activity>()
  *
  * fun onAttach(...) { mgr.consume(getActivity()) }
  * fun onDestroy(...) { mgr.clear() }

--- a/rxcomponents/src/main/java/com/redspace/utils/rxcomponents/components.kt
+++ b/rxcomponents/src/main/java/com/redspace/utils/rxcomponents/components.kt
@@ -42,19 +42,19 @@ interface ComponentConsumer<C> {
  */
 class ComponentManager<C> : ComponentProducer<C>, ComponentConsumer<C> {
 
-    private sealed class ComponentHolder<C> {
+    private sealed class ComponentHolder<out C> {
         object Empty : ComponentHolder<Nothing>()
-        data class Value<C>(val component: C) : ComponentHolder<C>()
+        data class Value<out C>(val component: C) : ComponentHolder<C>()
     }
 
     private val componentSubject = BehaviorSubject
-            .createDefault<ComponentHolder<out C>>(ComponentHolder.Empty)
+            .createDefault<ComponentHolder<C>>(ComponentHolder.Empty)
 
     override val component = componentSubject
             .flatMap<C> {
                 when (it) {
                     ComponentHolder.Empty -> Observable.empty()
-                    is ComponentHolder.Value<out C> -> Observable.just(it.component)
+                    is ComponentHolder.Value<C> -> Observable.just(it.component)
                 }
             }
             .firstOrError()

--- a/rxcomponents/src/main/java/com/redspace/utils/rxcomponents/components.kt
+++ b/rxcomponents/src/main/java/com/redspace/utils/rxcomponents/components.kt
@@ -1,0 +1,65 @@
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.subjects.BehaviorSubject
+
+/**
+ * ComponentProducer produces a component via a Single.
+ */
+interface ComponentProducer<C> {
+    val component: Single<C>
+}
+
+/**
+ * ComponentConsumer consumes a component, and allows that consumed component to then be cleared.
+ */
+interface ComponentConsumer<C> {
+    fun consume(component: C)
+    fun clear()
+}
+
+/**
+ * ComponentManager allows you to manage a 'temporary' component, and make sure that parts of your
+ * code don't try to access it when it is not available.
+ *
+ * For example, a common problem in using fragments is that getActivity() returns null sometimes,
+ * and it isn't always super predictable.  Using this class, we can make sure we accurately manage
+ * where and when we are providing this:
+ *
+ * ```
+ * val mgr = ComponentManager()
+ *
+ * fun onAttach(...) { mgr.consume(getActivity()) }
+ * fun onDestroy(...) { mgr.clear() }
+ * ```
+ *
+ * We can then safely allow other pieces of code to rely on it:
+ *
+ * ```
+ * mgr.component.subscribe { doSomethingWithActivity(it) }
+ * ```
+ *
+ * Note: it is up to the user of this class to manage their own Disposables.
+ */
+class ComponentManager<C> : ComponentProducer<C>, ComponentConsumer<C> {
+
+    private sealed class ComponentHolder<C> {
+        object Empty : ComponentHolder<Nothing>()
+        data class Value<C>(val component: C) : ComponentHolder<C>()
+    }
+
+    private val componentSubject = BehaviorSubject
+            .createDefault<ComponentHolder<out C>>(ComponentHolder.Empty)
+
+    override val component = componentSubject
+            .flatMap<C> {
+                when (it) {
+                    ComponentHolder.Empty -> Observable.empty()
+                    is ComponentHolder.Value<out C> -> Observable.just(it.component)
+                }
+            }
+            .firstOrError()
+
+    override fun consume(component: C) = componentSubject.onNext(ComponentHolder.Value(component))
+
+    override fun clear() = componentSubject.onNext(ComponentHolder.Empty)
+}

--- a/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
+++ b/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
@@ -1,0 +1,66 @@
+import org.junit.Test
+
+class ComponentsTests {
+
+    val testSubject = ComponentManager<Unit>()
+
+    @Test
+    fun `Given I am waiting for a component, when it becomes available, then I can execute my work`() {
+        // GIVEN
+        val obs = testSubject.component.test()
+
+        // WHEN
+        testSubject.consume(Unit)
+
+        // THEN
+        obs.assertValueCount(1).assertComplete()
+    }
+
+    @Test
+    fun `Given I am waiting for a component, if it never becomes available, then I never execute my work`() {
+        // GIVEN
+        val obs = testSubject.component.test()
+
+        // THEN
+        obs.assertNoValues().assertNotComplete().assertNoErrors()
+    }
+
+    @Test
+    fun `Given I am waiting for a component, if I clear, then I never execute my work`() {
+        // GIVEN
+        val obs = testSubject.component.test()
+
+        // WHEN
+        testSubject.clear()
+
+        // THEN
+        obs.assertNoValues().assertNotComplete().assertNoErrors()
+    }
+
+    @Test
+    fun `Given I have a component and clear it, when I start listening, then I never execute my work`() {
+        // GIVEN
+        testSubject.consume(Unit)
+        testSubject.clear()
+
+        // WHEN
+        val obs = testSubject.component.test()
+
+        // THEN
+        obs.assertNoValues().assertNotComplete().assertNoErrors()
+    }
+
+    @Test
+    fun `Given I have component A, when I set component B and listen, then I get component B`() {
+        // GIVEN
+        val testSubject = ComponentManager<String>()
+        testSubject.consume("A")
+
+        // WHEN
+        testSubject.consume("B")
+        val obs = testSubject.component.test()
+
+        // THEN
+        obs.assertComplete().assertValueCount(1).assertValueAt(0, { it == "B" })
+    }
+}

--- a/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
+++ b/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
@@ -1,7 +1,6 @@
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
-import org.junit.Test
 
 object ComponentSpec : Spek({
 

--- a/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
+++ b/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
@@ -1,66 +1,58 @@
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
 import org.junit.Test
 
-class ComponentsTests {
+object ComponentSpec : Spek({
 
-    val testSubject = ComponentManager<Unit>()
-
-    @Test
-    fun `Given I am waiting for a component, when it becomes available, then I can execute my work`() {
-        // GIVEN
+    describe("When waiting for a component") {
+        val testSubject = ComponentManager<Unit>()
         val obs = testSubject.component.test()
 
-        // WHEN
+        it("should not emit anything") {
+            obs.assertNoValues().assertNotComplete().assertNoErrors()
+        }
+    }
+
+    describe("When a component becomes available") {
+        val testSubject = ComponentManager<Unit>()
+        val obs = testSubject.component.test()
         testSubject.consume(Unit)
 
-        // THEN
-        obs.assertValueCount(1).assertComplete()
+        it("should emit the component") {
+            obs.assertValueCount(1).assertComplete()
+        }
     }
 
-    @Test
-    fun `Given I am waiting for a component, if it never becomes available, then I never execute my work`() {
-        // GIVEN
+    describe("When clear is executed with no available component") {
+        val testSubject = ComponentManager<Unit>()
         val obs = testSubject.component.test()
-
-        // THEN
-        obs.assertNoValues().assertNotComplete().assertNoErrors()
-    }
-
-    @Test
-    fun `Given I am waiting for a component, if I clear, then I never execute my work`() {
-        // GIVEN
-        val obs = testSubject.component.test()
-
-        // WHEN
         testSubject.clear()
 
-        // THEN
-        obs.assertNoValues().assertNotComplete().assertNoErrors()
+        it("should not emit anything") {
+            obs.assertNoValues().assertNotComplete().assertNoErrors()
+        }
     }
 
-    @Test
-    fun `Given I have a component and clear it, when I start listening, then I never execute my work`() {
-        // GIVEN
+    describe("When a component is cleared") {
+        val testSubject = ComponentManager<Unit>()
         testSubject.consume(Unit)
         testSubject.clear()
-
-        // WHEN
         val obs = testSubject.component.test()
 
-        // THEN
-        obs.assertNoValues().assertNotComplete().assertNoErrors()
+        it("should no longer be emitted") {
+            obs.assertNoValues().assertNotComplete().assertNoErrors()
+        }
     }
 
-    @Test
-    fun `Given I have component A, when I set component B and listen, then I get component B`() {
-        // GIVEN
+    describe("When I replace my component with a new one") {
         val testSubject = ComponentManager<String>()
         testSubject.consume("A")
-
-        // WHEN
         testSubject.consume("B")
         val obs = testSubject.component.test()
 
-        // THEN
-        obs.assertComplete().assertValueCount(1).assertValueAt(0, { it == "B" })
+        it("should only ever emit b") {
+            obs.assertValue("B")
+        }
     }
-}
+})

--- a/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
+++ b/rxcomponents/src/test/java/com/redspace/utils/rxcomponents/ComponentsTests.kt
@@ -40,7 +40,7 @@ object ComponentSpec : Spek({
         val obs = testSubject.component.test()
 
         it("should no longer be emitted") {
-            obs.assertNoValues().assertNotComplete().assertNoErrors()
+            obs.assertNotTerminated()
         }
     }
 


### PR DESCRIPTION
Rx Components

Allows code to easily wait on a required component (Such as an Activity instance in the case of fragment lifecycle concerns)