### PR TITLE
Feature/externalize group

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Note: do not add the jitpack.io repository under buildscript.
 
 Each directory in the project root (except `gradle`) is a module that can be imported.  Each module contains markdown with individual usage instructions.
 
+Note that JITpack compiles components on demand, which means that, if you're the first user of a given commit, dependency resolution might fail the first time.  Please retry a few times before
+reporting issues.
+
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,4 +35,6 @@ allprojects {
         google()
         jcenter()
     }
+
+    group = 'com.github.theREDspace.android-utils'
 }

--- a/durations/build.gradle
+++ b/durations/build.gradle
@@ -3,8 +3,6 @@ apply from: "$rootDir/java.gradle"
 apply plugin: 'kotlin'
 apply from: "$rootDir/kotlin.gradle"
 
-group = 'com.github.theREDspace.android-utils'
-
 dependencies {
     testImplementation 'org.amshove.kluent:kluent:1.38'
 }

--- a/javabreaker/build.gradle
+++ b/javabreaker/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'java'
 apply from: "$rootDir/java.gradle"
 
-group = 'com.github.theREDspace.android-utils'
-
 dependencies {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.assertj:assertj-core:$assertJVersion"

--- a/latestvaluecache/build.gradle
+++ b/latestvaluecache/build.gradle
@@ -3,8 +3,6 @@ apply from: "$rootDir/java.gradle"
 apply plugin: 'kotlin'
 apply from: "$rootDir/kotlin.gradle"
 
-group = 'com.github.theREDspace.android-utils'
-
 dependencies {
     implementation "io.reactivex.rxjava2:rxjava:2.1.14"
     testImplementation 'org.amshove.kluent:kluent:1.38'

--- a/startsnaphelper/build.gradle
+++ b/startsnaphelper/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.android.library'
 apply from: "$rootDir/android.gradle"
 
-group = 'com.github.theREDspace.android-utils'
-
 dependencies {
     api "com.android.support:recyclerview-v7:$supportVersion"
     api "com.android.support:appcompat-v7:$supportVersion"


### PR DESCRIPTION
Moved things around so that each project doesn't need to specify the same group tag.

Also added a warning to README to cover for JITpack's occasional tendency to fail resolution due to longer builds.