### PR TITLE
Feature/durations revision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,10 @@ buildscript {
         junitVersion = '4.12'
         assertJVersion = '3.10.0'
 
+        junit5Version = '5.2.0'
+        kluentVersion = '1.38'
+        spekVersion = '1.1.5'
+
         buildToolsVersion = '27.0.2'
 
         versionCode = 1
@@ -27,6 +31,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.0.0"
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.3'
     }
 }
 

--- a/durations/build.gradle
+++ b/durations/build.gradle
@@ -2,7 +2,4 @@ apply plugin: 'java'
 apply from: "$rootDir/java.gradle"
 apply plugin: 'kotlin'
 apply from: "$rootDir/kotlin.gradle"
-
-dependencies {
-    testImplementation 'org.amshove.kluent:kluent:1.38'
-}
+apply from: "$rootDir/spek.gradle"

--- a/durations/src/test/java/DurationTests.kt
+++ b/durations/src/test/java/DurationTests.kt
@@ -1,13 +1,34 @@
 package com.redspace.durations
 
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeInstanceOf
-import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.*
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
 import org.junit.Test
 import java.util.concurrent.TimeUnit
 
-class DurationTests {
+object InternedZerosSpec : Spek({
+    val cases = mapOf(
+            TimeUnit.NANOSECONDS to Duration.Zero.nanoseconds,
+            TimeUnit.MICROSECONDS to Duration.Zero.microseconds,
+            TimeUnit.MILLISECONDS to Duration.Zero.milliseconds,
+            TimeUnit.SECONDS to Duration.Zero.seconds,
+            TimeUnit.MINUTES to Duration.Zero.minutes,
+            TimeUnit.HOURS to Duration.Zero.hours,
+            TimeUnit.DAYS to Duration.Zero.days
+    )
 
+    cases.forEach { unit, zeroType ->
+        describe("zero constant for the unit $unit") {
+            val duration = unitConstructor(unit)(0)
+            it("should equal $zeroType") {
+                duration shouldEqual zeroType
+            }
+        }
+    }
+})
+
+class DurationTests {
     @Test
     fun `Given two equal durations, when I compare them, then I expect a 0`() {
         // GIVEN
@@ -22,7 +43,7 @@ class DurationTests {
     }
 
     @Test
-    fun `Given a small duration, when I compare it to a large duration, then I expect a -1`() {
+    fun `Given a small duration, when I compare it to a large duration, then I expect below 0`() {
         // GIVEN
         val large = days(4)
         val small = hours(5)
@@ -31,11 +52,11 @@ class DurationTests {
         val result = small.compareTo(large)
 
         // THEN
-        result shouldEqual -1
+        result shouldBeLessThan 0
     }
 
     @Test
-    fun `Given a large duration, when I compare it to a small duration, then I expect a 1`() {
+    fun `Given a large duration, when I compare it to a small duration, then I expect more than 0`() {
         // GIVEN
         val large = days(4)
         val small = hours(5)
@@ -44,7 +65,7 @@ class DurationTests {
         val result = large.compareTo(small)
 
         // THEN
-        result shouldEqual 1
+        result shouldBeGreaterThan 0
     }
 
     @Test
@@ -120,7 +141,7 @@ class DurationTests {
         val us = ns.microseconds
 
         // THEN
-        us.duration shouldEqual 0
+        us shouldEqual zero
     }
 
     @Test
@@ -132,7 +153,7 @@ class DurationTests {
         val ms = us.milliseconds
 
         // THEN
-        ms.duration shouldEqual 0
+        ms shouldEqual zero
     }
 
     @Test
@@ -144,7 +165,7 @@ class DurationTests {
         val s = ms.seconds
 
         // THEN
-        s.duration shouldEqual 0
+        s shouldEqual zero
     }
 
     @Test
@@ -156,7 +177,7 @@ class DurationTests {
         val m = s.minutes
 
         // THEN
-        m.duration shouldEqual 0
+        m shouldEqual zero
     }
 
     @Test
@@ -168,7 +189,7 @@ class DurationTests {
         val h = m.hours
 
         // THEN
-        h.duration shouldEqual 0
+        h shouldEqual zero
     }
 
     @Test
@@ -180,7 +201,7 @@ class DurationTests {
         val d = h.days
 
         // THEN
-        d.duration shouldEqual 0
+        d shouldEqual zero
     }
 
     @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/java.gradle
+++ b/java.gradle
@@ -1,5 +1,13 @@
+
 dependencies {
-    testCompile "junit:junit:$junitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit5Version"
+    testCompileOnly "junit:junit:$junitVersion"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 apply plugin: 'maven'

--- a/kotlin.gradle
+++ b/kotlin.gradle
@@ -1,3 +1,5 @@
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    testImplementation "org.amshove.kluent:kluent:$kluentVersion"
 }

--- a/spek.gradle
+++ b/spek.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'org.junit.platform.gradle.plugin'
+
+junitPlatform {
+    filters {
+        engines {
+            include "spek"
+        }
+    }
+}
+
+dependencies {
+    testImplementation("org.jetbrains.spek:spek-api:$spekVersion") {
+        exclude group: 'org.jetbrains.kotlin'
+    }
+
+    testImplementation("org.jetbrains.spek:spek-junit-platform-engine:$spekVersion") {
+        exclude group: 'org.junit.platform'
+        exclude group: 'org.jetbrains.kotlin'
+    }
+}


### PR DESCRIPTION
Two commits, each doing something separate:
* Adding Spek test framework for concise and Kotlinesque parameterized tests.  I wasn't sure about it but I think I really like it.
* Adding zero interning for durations, and also privatizing the Long duration value at the top level, because it enables breaking encapsulation some.

Future work: consider whether we should fully hide/eliminate the per-unit types, and make the `milliseconds`, etc. accessors become to-Long conversion operators instead.