### PR TITLE
Add sources to Java and Android projects

### DIFF
--- a/android.gradle
+++ b/android.gradle
@@ -70,6 +70,15 @@ project.plugins.forEach { plugin ->
                     task.dependsOn += 'generateAndroidManifest'
             }
         }
+
+        task sourcesJar(type: Jar) {
+            from android.sourceSets.main.java.srcDirs
+            classifier = 'sources'
+        }
+
+        artifacts {
+            archives sourcesJar
+        }
     }
 }
 

--- a/java.gradle
+++ b/java.gradle
@@ -11,3 +11,12 @@ test {
 }
 
 apply plugin: 'maven'
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}
+
+artifacts {
+    archives sourcesJar
+}


### PR DESCRIPTION
@markmckenna Is it ok to introduce this as such? Or would it be better to define a `java-sources.gradle` and `android-sources.gradle` file which a given project can import directly?

Android sourceSets have a slightly different method of access than java sourceSets. See:
https://stackoverflow.com/questions/11474729/how-to-build-sources-jar-with-gradle#11475089
